### PR TITLE
Updating to the latest version of uglifycss

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-util": "^3.0.1",
     "lodash.defaults": "^2.4.1",
     "through2": "^0.6.3",
-    "uglifycss": "^0.0.11"
+    "uglifycss": "^0.0.18"
   },
   "devDependencies": {
     "jshint": "^2.5.10",


### PR DESCRIPTION
We've encountered a bug with using the css `calc` method and when the code is minified, it removes all spaces in the `calc` which causes some inconsistencies in deployed environments. It looks like the latest version of `uglifycss` has fixed this. 