### PR TITLE
Fixed UglifyCSS options format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ var uglifycss = require('gulp-uglifycss');
 gulp.task('css', function () {
   gulp.src('./styles/**/*.css')
     .pipe(uglifycss({
-      "max-line-len": 80
+      "maxLineLen": 80,
+      "uglyComments": true
     }))
     .pipe(gulp.dest('./dist/'));
 });


### PR DESCRIPTION
For using options of UglifyCSS, I found `max-line-len` style keys has no impact. Rather, as described in *API* section of UglifyCSS's readme, `maxLineLen` format is working perfectly!